### PR TITLE
drop seemingly redundant each

### DIFF
--- a/lib/flay.rb
+++ b/lib/flay.rb
@@ -194,10 +194,8 @@ class Flay
     # extract all subtree hashes from all nodes
     all_hashes = {}
     self.hashes.values.each do |nodes|
-      nodes.each do |node|
-        node.all_structural_subhashes.each do |h|
-          all_hashes[h] = true
-        end
+      nodes.first.all_structural_subhashes.each do |h|
+        all_hashes[h] = true
       end
     end
 

--- a/test/test_flay.rb
+++ b/test/test_flay.rb
@@ -50,6 +50,23 @@ class TestSexp < MiniTest::Unit::TestCase
     assert_equal expected, x.sort.uniq
   end
 
+  def test_prune
+
+    contained = s(:a,s(:b,s(:c)))
+    container = s(:d,contained)
+
+    flay = Flay.new :mass => 0
+    flay.process_sexp s(:outer,contained)
+    2.times { flay.process_sexp s(:outer,container) }
+
+    assert_equal 3, flay.hashes[contained.structural_hash].length
+
+    flay.prune
+
+    refute flay.hashes.include? contained.structural_hash
+
+  end
+
   def test_process_sexp
     flay = Flay.new
 


### PR DESCRIPTION
Hi - enjoyed reading through flay a lot. On looking at `prune` I saw that you're looping through all the nodes for each hash and removing any sub-hashes they contain to give you only the largest. Since the nodes you're looping over are already grouped by structural hash, isn't it redundant, as they have identical structures?
