### PR TITLE
Return a non-zero exit code when matches exist

### DIFF
--- a/bin/flay
+++ b/bin/flay
@@ -8,3 +8,5 @@ files = Flay.expand_dirs_to_files(*ARGV)
 
 flay.process(*files)
 flay.report
+
+exit flay.exit_code

--- a/lib/flay.rb
+++ b/lib/flay.rb
@@ -521,6 +521,10 @@ class Flay
     @r2r ||= Ruby2Ruby.new
     @r2r.process sexp.deep_clone
   end
+
+  def exit_code
+    hashes.size
+  end
 end
 
 class String


### PR DESCRIPTION
This is just to get the conversation started around some code to solve #34.

Just as an example, [rails_best_practices returns the number of errors found as the exit code](https://github.com/railsbp/rails_best_practices/blob/0a44a455d57075dfe8b31a1f15d5b1857b166a84/lib/rails_best_practices/command.rb#L138). But [reek doesn't](https://github.com/troessner/reek/blob/f0c2a9e0e330795b43e3bf08d19f474ccb8f2f98/lib/reek/cli/application.rb#L13-L15).
I don't feel strongly one way or the other. But if you're not using the exit codes for anything else, why not? It could be useful.

Also, should this really need a flag to work? Shouldn't this just be the default behavior of the executable?
