### PR TITLE
Fix passing in './'-prefixed filenames on command-line

### DIFF
--- a/lib/flay.rb
+++ b/lib/flay.rb
@@ -134,8 +134,9 @@ class Flay
       else
         p
       end
-    }.flatten.map { |s| s[/^(\.\/)?/] = ""; s } # strip "./" from paths
+    }.flatten.map { |s| s.sub(/^\.\//, "") } # strip "./" from paths
   end
+
 
   # so I can move this to flog wholesale
   DEFAULT_IGNORE = ".flayignore" # :nodoc:

--- a/test/test_flay.rb
+++ b/test/test_flay.rb
@@ -478,4 +478,10 @@ class TestSexp < Minitest::Test
     assert_filter_files miss, "test"
     assert_filter_files miss, "nope"
   end
+
+  def test_expand_dirs_on_frozen_string
+    s = "./foo"
+    s.freeze
+    assert_equal Flay.expand_dirs_to_files([s]), ["foo"]
+  end
 end


### PR DESCRIPTION
Looks like the most recent release added some code to strip out './' from filenames, but didn't account for the fact that command-line argument strings come in frozen and can't be modified.  This patch works around that.

Here's the problem in action:

broz@macbook:~/src/flay$ bin/flay ./test/test_flay.rb
/Users/broz/.rvm/gems/ruby-2.1.5/gems/flay-2.6.0/lib/flay.rb:137:in `[]=': can't modify frozen String (RuntimeError)
        from /Users/broz/.rvm/gems/ruby-2.1.5/gems/flay-2.6.0/lib/flay.rb:137:in `block in expand_dirs_to_files'
        from /Users/broz/.rvm/gems/ruby-2.1.5/gems/flay-2.6.0/lib/flay.rb:137:in `map'
        from /Users/broz/.rvm/gems/ruby-2.1.5/gems/flay-2.6.0/lib/flay.rb:137:in `expand_dirs_to_files'
        from bin/flay:7:in `<main>'
broz@macbook:~/src/flay$