### PR TITLE
Add test for potential filter and pruning conflict

### DIFF
--- a/test/test_flay.rb
+++ b/test/test_flay.rb
@@ -448,4 +448,28 @@ class TestSexp < Minitest::Test
 
     assert_equal exp, flay.n_way_diff(*dog_and_cat).gsub(/^ {3}$/, "")
   end
+
+  def test_prune_and_filter_conflict
+    exp_foo = s(:program,
+      s(:filter_me,
+        s(:a, s(:b))
+      )
+    )
+
+    exp_bar = s(:program,
+      s(:filter_me,
+        s(:a, s(:b)),
+        s(:c)
+      )
+    )
+
+    filter = Sexp::Matcher.parse("(filter_me ___)")
+    options = Flay.default_options.merge(mass: 0, filters: [filter])
+    flay = Flay.new(options)
+    flay.process_sexp exp_foo
+    flay.process_sexp exp_bar
+    flay.analyze
+
+    assert flay.hashes.empty?, flay.hashes.inspect
+  end
 end


### PR DESCRIPTION
Hello @zenspider,

We may have discovered a conflict between filtering and pruning behavior in Flay, and created a unit test to demonstrate it. The expectation is that the `filter_me` node and all of its children are not analyzed for duplication.

Please note that if the following step is skipped in `Flay#prune`:

```ruby
self.hashes.delete_if { |_,nodes| nodes.size == 1 }
```

This test (and all others) pass.

Thanks for your help!

### Test failure

```
  1) Failure:
TestSexp#test_prune_and_filter_conflict [/Users/tmazierski/code/flay/test/test_flay.rb:473]:
{1024335973=>[s(:a, s(:b)), s(:a, s(:b))]}
```